### PR TITLE
V3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,27 @@ const ServerCookies = await Cookies('server');
 
 > **Note**: Both client and server contexts require `await` for initialization to comply with Next.js 15's stricter cookie handling. Once initialized, all cookie operations (`get`, `set`, `remove`, `has`, `clear`) are synchronous.
 
+### Direct Import (Alternative)
+You can also import client and server cookies directly:
+
+```js
+import { CookiesClient, CookiesServer } from 'next-cookies-universal';
+
+// Direct client cookies (no await required)
+const clientCookies = CookiesClient();
+
+// Direct server cookies (requires await for initialization)
+const serverCookies = await CookiesServer();
+```
+
+> **Note**: `CookiesClient()` can be used synchronously without `await`, while `CookiesServer()` still requires `await` for initialization. Both provide the same functionality as the main `Cookies()` function but offer better code clarity and developer experience.
+
 ### Client Component
 ```jsx
 'use client';
 
 import Cookies from 'next-cookies-universal';
+// Or use direct import: import { CookiesClient } from 'next-cookies-universal';
 import { useEffect, useState } from 'react';
 
 
@@ -77,6 +93,7 @@ const MyClientComponent = () => {
   useEffect(() => {
     const initCookies = async () => {
       const cookieInstance = await Cookies('client');
+      // Or with direct import: const cookieInstance = CookiesClient();
       setCookies(cookieInstance);
     };
     initCookies();
@@ -129,10 +146,12 @@ const MyClientComponent = () => {
 ### Server Component
 ```jsx
 import Cookies from 'next-cookies-universal';
+// Or use direct import: import { CookiesServer } from 'next-cookies-universal';
 
 
 const MyServerComponent = async() => {
   const cookies = await Cookies('server');
+  // Or with direct import: const cookies = await CookiesServer();
   const myToken = cookies.get('my_token');
 
   const data = await fetch('http://your.endpoint', {
@@ -183,11 +202,13 @@ const MyServerComponent = async() => {
 #### With Server Component
 ```tsx
 import Cookies from 'next-cookies-universal';
+// Or use direct import: import { CookiesServer } from 'next-cookies-universal';
 
 async function setFromAction(formData: FormData) {
   'use server';
 
   const cookies = await Cookies('server');
+  // Or with direct import: const cookies = await CookiesServer();
   cookies.set('my_token', formData.get('cookie-value'));
 }
 
@@ -211,8 +232,12 @@ function Form() {
 /** action.ts */
 'use server';
 
+import Cookies from 'next-cookies-universal';
+// Or use direct import: import { CookiesServer } from 'next-cookies-universal';
+
 export async function setFromAction(formData: FormData) {
   const cookies = await Cookies('server');
+  // Or with direct import: const cookies = await CookiesServer();
   cookies.set('my_token', formData.get('cookie-value'));
 }
 ```
@@ -320,12 +345,13 @@ async function setTokenWithExpiry(formData: FormData) {
 - **maxAge**: Specifies the cookie expiration time in seconds (relative to current time)
 - **expires**: Specifies the exact date and time when the cookie should expire (absolute time)
 - **Client-side**:
-  - Requires `await` for initialization: `const cookies = await Cookies('client')`
+  - `Cookies('client')` requires `await` for initialization: `const cookies = await Cookies('client')`
+  - `CookiesClient()` can be used synchronously: `const cookies = CookiesClient()`
   - Once initialized, all cookie operations are synchronous
   - The `maxAge` option is automatically converted to an `expires` Date object for compatibility with `js-cookie`
   - The `expires` option accepts a Date object directly
 - **Server-side**:
-  - Requires `await` for initialization: `const cookies = await Cookies('server')`
+  - Both `Cookies('server')` and `CookiesServer()` require `await` for initialization
   - Once initialized, all cookie operations are synchronous
   - Uses Next.js built-in cookie handling which supports both `maxAge` and `expires` directly
 - **Choosing between maxAge and expires**:
@@ -378,6 +404,10 @@ export interface IServerCookies {
 /** Function overloads */
 function Cookies(context: 'client'): Promise<IClientCookies>;
 function Cookies(context: 'server'): Promise<IServerCookies>;
+
+/** Direct import functions */
+function CookiesClient(): IClientCookies;
+function CookiesServer(): Promise<IServerCookies>;
 ```
 
 for `ICookiesOptions` API, we use `CookieSerializeOptions` from [DefinetlyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/cookie/index.d.ts#L14)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-cookies-universal",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next-cookies-universal",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",
@@ -5918,6 +5918,8 @@
       }
     },
     "packages/next-cookies-universal": {
+      "version": "0.0.0",
+      "license": "MIT",
       "devDependencies": {
         "@types/cookie": "^0.5.1",
         "@types/js-cookie": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-cookies-universal",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "Sutan Gading Fadhillah Nasution <contact@gading.dev>",
   "description": "An utility that can help you to handle the Cookies in NextJS App Route with every context (both Server or Client) 🍪🔥",
   "license": "MIT",

--- a/packages/next-cookies-universal/src/index.ts
+++ b/packages/next-cookies-universal/src/index.ts
@@ -2,8 +2,8 @@
 /** Cookie.ts */
 
 import type { ICookiesContext, IBaseCookies, ICookiesOptions } from './Cookies.interface';
-import CookiesClient from './Cookies.client';
-import CookiesServer from './Cookies.server';
+import BaseCookiesClient from './Cookies.client';
+import BaseCookiesServer from './Cookies.server';
 
 /**
  * Universal cookies function that works in both client and server contexts
@@ -12,16 +12,25 @@ import CookiesServer from './Cookies.server';
  */
 function Cookies(context: ICookiesContext): Promise<IBaseCookies> {
   if (context === 'client') {
-    const clientCookies = new CookiesClient();
+    const clientCookies = new BaseCookiesClient();
     return Promise.resolve(clientCookies);
   }
 
   if (context === 'server') {
-    const serverCookies = new CookiesServer();
+    const serverCookies = new BaseCookiesServer();
     return serverCookies.initialize();
   }
 
   throw new Error(`Invalid context: ${context}. Use 'client' or 'server'.`);
+}
+
+export function CookiesClient(): IBaseCookies {
+  return new BaseCookiesClient();
+}
+
+export function CookiesServer(): Promise<IBaseCookies> {
+  const serverCookies = new BaseCookiesServer();
+  return serverCookies.initialize();
 }
 
 export type { IBaseCookies, ICookiesContext, ICookiesOptions };


### PR DESCRIPTION
## Pull Request: Add Direct Import Functions for Enhanced Developer Experience

### Overview
This PR introduces direct import functions for `CookiesClient` and `CookiesServer` as alternatives to the main `Cookies()` function, improving code clarity and developer experience while maintaining full backward compatibility.

### Changes Made

#### Commit 1: `c53d622d94b9246047e7c48ef93405eddf38da89`
**refactor(cookies): rename cookie classes and add direct export functions**

- **Internal Refactoring:**
  - Renamed `CookiesClient` class to `BaseCookiesClient` for better internal clarity
  - Renamed `CookiesServer` class to `BaseCookiesServer` for better internal clarity
  
- **New Direct Export Functions:**
  - Added `CookiesClient()` function that returns `IBaseCookies` synchronously
  - Added `CookiesServer()` function that returns `Promise<IBaseCookies>` asynchronously
  - These functions provide cleaner, more intuitive API for developers

- **Backward Compatibility:**
  - All existing `Cookies('client')` and `Cookies('server')` usage remains unchanged
  - No breaking changes to public API

#### Commit 2: `7030a0f5be0e62cd47054155d2c7cc424393192f`
**docs: add direct import option documentation for next-cookies-universal**

- **Documentation Updates:**
  - Added comprehensive documentation for new direct import functions
  - Updated "Important Notes" section to clarify `await` requirements
  - Added API Reference entries for `CookiesClient()` and `CookiesServer()`
  - Included usage examples throughout the documentation

### Benefits

1. **Improved Developer Experience:**
   - More intuitive function names that clearly indicate their purpose
   - Reduced cognitive load when choosing between client/server implementations

2. **Better Code Clarity:**
   - Direct imports make code intent more explicit
   - Easier to understand at a glance whether client or server cookies are being used

3. **Maintained Flexibility:**
   - Developers can choose between the original `Cookies()` function or direct imports
   - Both approaches offer the same functionality

### Usage Examples

**Before (still supported):**
```typescript
const cookies = await Cookies('client');
const serverCookies = await Cookies('server');
```

**After (new alternative options):**
```typescript
const cookies = CookiesClient(); // No await needed
const serverCookies = await CookiesServer(); // Still requires await
```

### Testing
- All existing functionality remains intact
- New functions provide identical behavior to their `Cookies()` counterparts
- Documentation updated with comprehensive examples